### PR TITLE
README – fix install typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Implemented using axios interceptors
 ## Installing
 
 ```bash
-$ npm install axios-concurrecy
+$ npm install axios-concurrency
 ```
 
 ## Example


### PR DESCRIPTION
Just made a lazy copy/paste and it wasn't working…

And thanks for this library !